### PR TITLE
Fix truthy errors from API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,9 +20,7 @@ Rest.prototype.authenticate = function(email, password) {
     .then(function(response) {
       _this.context.authenticationToken = response.body.authenticationToken;
       resolve(response);
-    }).catch(function(error) {
-      reject(error);
-    });
+    }).catch(reject);
   });
 };
 
@@ -34,9 +32,7 @@ Rest.prototype.unauthenticate = function() {
     .then(function(response) {
       _this.context.authenticationToken = null;
       resolve(response);
-    }).catch(function(error) {
-      reject(error);
-    });
+    }).catch(reject);
   });
 };
 
@@ -89,9 +85,7 @@ Rest.prototype._dispatch = function(method, path, params) {
       }
 
       resolve(response);
-    }).catch(function(error) {
-      resolve(error);
-    });
+    }).catch(reject);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kisi-client",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "JavaScript client for interacting with the KISI API",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
For all REST methods (with exception of authentication) errors came from
a kisi server where consumed by success callback, forcing clients to
handle it somehow. Because of this changing MAJOR version, since
this fix make for them API backward incompatible.