### PR TITLE
Fix ignored query params in GET requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ Rest.prototype.unauthenticate = function() {
 };
 
 Rest.prototype.get = function(path, params) {
-  return this._dispatch('GET', path, params);
+  return this._dispatch('GET', path, null, params);
 };
 
 Rest.prototype.post = function(path, params) {
@@ -52,7 +52,7 @@ Rest.prototype.delete = function(path, params) {
   return this._dispatch('DELETE', path, params);
 };
 
-Rest.prototype._dispatch = function(method, path, params) {
+Rest.prototype._dispatch = function(method, path, params, queryParams) {
   if (method === 'DELETE') {
     method = 'del';
   }
@@ -61,6 +61,7 @@ Rest.prototype._dispatch = function(method, path, params) {
   return new Promise(function(resolve, reject) {
     request[method.toLowerCase()](_this.context.baseUrl + '/' + path)
     .send(humps.decamelizeKeys(params))
+    .query(humps.decamelizeKeys(queryParams))
     .set('Accept', 'application/json')
     .set('X-Authentication-Token', _this.context.authenticationToken)
     .retry(_this.context.retries)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kisi-client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "JavaScript client for interacting with the KISI API",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
This fix relates only to GET requests. 
But issue may affect on other methods if query params are expected @ce07c3 do we have such case?