### PR TITLE
Extend support for pagination

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,12 @@ Rest.prototype.unauthenticate = function() {
 };
 
 Rest.prototype.get = function(path, params) {
+  if (params && params.page && params.limit) {
+    var page = params.page;
+    delete params.page;
+
+    params.offset = (page - 1) * params.limit;
+  }
   return this._dispatch('GET', path, null, params);
 };
 
@@ -84,16 +90,20 @@ Rest.prototype._dispatch = function(method, path, params, queryParams) {
       if (collectionRange !== undefined) {
         var rangeAndCount = collectionRange.split('/');
         var rangeStartAndEnd = rangeAndCount[0].split('-');
-        var collectionStart = rangeStartAndEnd[0];
-        var collectionEnd = rangeStartAndEnd[1];
-        var collectionCount = rangeAndCount[1];
-        var collectionLimit = collectionEnd - collectionStart + 1;
+        var collectionStart = Number(rangeStartAndEnd[0]);
+        var collectionEnd = Number(rangeStartAndEnd[1]);
+        var collectionCount = Number(rangeAndCount[1]);
+        var collectionLimit = Number(collectionEnd - collectionStart + 1);
 
+        queryParams = queryParams || {};
         response.body = {
           items: response.body,
           offset: collectionStart,
           limit: collectionLimit,
-          count: collectionCount
+          count: collectionCount,
+          page: Math.ceil((collectionEnd + 1) / queryParams.limit) || 1,
+          lastPage: Math.ceil(collectionCount / queryParams.limit) || 1,
+          query: queryParams
         };
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kisi-client",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "JavaScript client for interacting with the KISI API",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
- Add optional GET query param `page` which in the hood
computes `offset` sent further to the client. `page` requres
to specify `limit` as well, otherwhise it is ignored. `page`
property isn't used in the request.
- Add fields in GET ranged respones:
  * `page` - current page
  * `lastPage`
  * `query` - (almost) original query (with already computed `offset`
              and dropped `page`)
- Increase minor wersion to 3.1.0

kisi-inc/web-react#29