### PR TITLE
Make copy of GET params

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var humps = require('humps');
 var Promise = require('bluebird');
 var request = require('superagent-bluebird-promise');
@@ -47,11 +48,9 @@ Rest.prototype.unauthenticate = function() {
 };
 
 Rest.prototype.get = function(path, params) {
+  params = _.cloneDeep(params);
   if (params && params.page && params.limit) {
-    var page = params.page;
-    delete params.page;
-
-    params.offset = (page - 1) * params.limit;
+    params.offset = (params.page - 1) * params.limit;
   }
   return this._dispatch('GET', path, null, params);
 };
@@ -77,7 +76,7 @@ Rest.prototype._dispatch = function(method, path, params, queryParams) {
   return new Promise(function(resolve, reject) {
     request[method.toLowerCase()](_this.context.baseUrl + '/' + path)
     .send(humps.decamelizeKeys(params))
-    .query(humps.decamelizeKeys(queryParams))
+    .query(humps.decamelizeKeys(_.omit(queryParams, 'page')))
     .set('Accept', 'application/json')
     .set('X-Authentication-Token', _this.context.authenticationToken)
     .retry(_this.context.retries)
@@ -96,6 +95,7 @@ Rest.prototype._dispatch = function(method, path, params, queryParams) {
         var collectionLimit = Number(collectionEnd - collectionStart + 1);
 
         queryParams = queryParams || {};
+
         response.body = {
           items: response.body,
           offset: collectionStart,
@@ -103,7 +103,7 @@ Rest.prototype._dispatch = function(method, path, params, queryParams) {
           count: collectionCount,
           page: Math.ceil((collectionEnd + 1) / queryParams.limit) || 1,
           lastPage: Math.ceil(collectionCount / queryParams.limit) || 1,
-          query: queryParams
+          query: _.omit(queryParams, 'offset')
         };
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kisi-client",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "JavaScript client for interacting with the KISI API",
   "main": "lib/index.js",
   "repository": {
@@ -21,6 +21,7 @@
   "dependencies": {
     "bluebird": "~ 2.9.24",
     "humps": "~ 0.5.1",
+    "lodash": "^3.9.3",
     "superagent-bluebird-promise": "~ 2.0.0",
     "superagent-retry": "~ 0.5.0"
   },


### PR DESCRIPTION
Introducing 'page' feature in pagination caused changing
original object passed to the client. It is not always
desired to to that, that's why doing a clone.

Started using lodash.

Relates to kisi-inc/web-react#36