### PR TITLE
bugfix: stringify search query object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,9 +74,18 @@ Rest.prototype._dispatch = function(method, path, params, queryParams) {
 
   var _this = this;
   return new Promise(function(resolve, reject) {
+    var readyQueryParams;
+    if (queryParams) {
+      readyQueryParams = humps.decamelizeKeys(_.omit(queryParams, 'page'))
+
+      if (readyQueryParams.q instanceof Object) {
+        readyQueryParams.q = JSON.stringify(readyQueryParams.q);
+      }
+    }
+
     request[method.toLowerCase()](_this.context.baseUrl + '/' + path)
     .send(humps.decamelizeKeys(params))
-    .query(humps.decamelizeKeys(_.omit(queryParams, 'page')))
+    .query(readyQueryParams)
     .set('Accept', 'application/json')
     .set('X-Authentication-Token', _this.context.authenticationToken)
     .retry(_this.context.retries)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kisi-client",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "JavaScript client for interacting with the KISI API",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
When querying API with search query (`q` query param), under the hood superagent is using native JS function `encodeURIComponent` to serialize each query param, changing complex Objects to `[object Object]`. To not force clients to reimplement `SearchQuery.property.toString` we are stringifying it before it gets to superagent, making this truly transparent.

Relates to kisi-inc/web-react#149.