### PR TITLE
Remove retry feature

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,15 +3,12 @@ var humps = require('humps');
 var Promise = require('bluebird');
 var request = require('superagent-bluebird-promise');
 
-require('superagent-retry')(request);
-
 function Rest(config) {
   config = config || {};
 
   this.context = {
     authenticationToken: null,
     baseUrl: 'https://my.getKisi.com/api',
-    retries: 0,
     camelize: config.camelize || true
   };
 }
@@ -88,7 +85,6 @@ Rest.prototype._dispatch = function(method, path, params, queryParams) {
     .query(readyQueryParams)
     .set('Accept', 'application/json')
     .set('X-Authentication-Token', _this.context.authenticationToken)
-    .retry(_this.context.retries)
     .then(function(response) {
       if (_this.context.camelize) {
         response.body = humps.camelizeKeys(response.body);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kisi-client",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "JavaScript client for interacting with the KISI API",
   "main": "lib/index.js",
   "repository": {
@@ -15,15 +15,14 @@
   "browserDependencies": {
     "bluebird": "~ 2.9.24",
     "humps": "~ 0.5.1",
-    "superagent-bluebird-promise": "~ 2.0.0",
-    "superagent-retry": "~ 0.5.0"
+    "superagent-bluebird-promise": "~ 2.0.0"
   },
   "dependencies": {
-    "bluebird": "~ 2.9.24",
-    "humps": "~ 0.5.1",
-    "lodash": "^3.9.3",
-    "superagent-bluebird-promise": "~ 2.0.0",
-    "superagent-retry": "~ 0.5.0"
+    "bluebird": "~2.9.24",
+    "humps": "~0.5.1",
+    "lodash": "~3.9.3",
+    "superagent": "~1.2.0",
+    "superagent-bluebird-promise": "~ 2.0.0"
   },
   "devDependencies": {
     "browserify": "~ 9.0.8"


### PR DESCRIPTION
- superagent-retry is buggy and doesn't handle properly 50x
- bugfix: npm warrnings about droping auto-fetch peerDeps so included all peers

Relates to kisi-inc/web-react#69.