### PR TITLE
Fix for double slash issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var url = require('url');
 var humps = require('humps');
 var Promise = require('bluebird');
 var request = require('superagent-bluebird-promise');
@@ -74,14 +75,14 @@ Rest.prototype._dispatch = function(method, path, params, queryParams) {
   return new Promise(function(resolve, reject) {
     var readyQueryParams;
     if (queryParams) {
-      readyQueryParams = humps.decamelizeKeys(_.omit(queryParams, 'page'))
+      readyQueryParams = humps.decamelizeKeys(_.omit(queryParams, 'page'));
 
       if (readyQueryParams.q instanceof Object) {
         readyQueryParams.q = JSON.stringify(readyQueryParams.q);
       }
     }
 
-    request[method.toLowerCase()](_this.context.baseUrl + '/' + path)
+    request[method.toLowerCase()](url.resolve(_this.context.baseUrl, path))
     .send(humps.decamelizeKeys(params))
     .query(readyQueryParams)
     .set('Accept', 'application/json')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kisi-client",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "JavaScript client for interacting with the KISI API",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
If someone will pass to the path value with leading slash e.g. `/abc` we will concatenate it as a `https://hostname//abc`, which is not correct.

This changeset resolves that issue, and makes that more *bulletproof* for the future. :wink:

I have bumped up patch version, because it should not affect anyone (it is actually kind of *bugfix*).