### PR TITLE
Updated Axios

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,5 +10,7 @@
         }
       }
     ]
-  ]
+  ],
+
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run build && mocha --compilers js:babel-core/register"
   },
   "dependencies": {
-    "axios": "^0.14.0",
+    "axios": "^0.19.0",
     "babel-polyfill": "^6.16.0",
     "humps": "^1.1.0",
     "regenerator-runtime": "^0.11.0"
@@ -19,6 +19,7 @@
   "devDependencies": {
     "axios-mock-adapter": "^1.6.1",
     "babel-cli": "^6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "chai": "^3.5.0",
     "eslint": "^3.10.2",


### PR DESCRIPTION
I'm getting a [high severity security alert](https://nvd.nist.gov/vuln/detail/CVE-2019-10742) in a [project I'm working on](https://github.com/dheidelberger/kisi-report-generator) with your client-js related to your Axios dependency. The fix is to update Axios to version 19+, which is what this pull request does. 

I also had to add the [babel-object-rest-spread plugin](https://babeljs.io/docs/en/babel-plugin-proposal-object-rest-spread) in order to build the project due to an "Unexpected Token" error I was getting about the spread operator on [line 24 of index.js](https://github.com/kisi-inc/client-js/blob/98dda2367c8e78d6a1ab8495f926b11b006f367b/src/index.js#L24)